### PR TITLE
修复页面标题错误、XML高亮显示错误

### DIFF
--- a/components/Tags.vue
+++ b/components/Tags.vue
@@ -12,7 +12,7 @@ export default {
 }
 </script>
 
-<style lang="stylus">
+<style lang="stylus" scoped>
 @import '../styles/config.styl'
 .tag
     background: linear-gradient(120deg, #ffffff 50%, $readMoreBgColor 0%);

--- a/layouts/FrontmatterPagination.vue
+++ b/layouts/FrontmatterPagination.vue
@@ -28,7 +28,7 @@ export default {
         Pagination: () => import(/* webpackChunkName = "Pagination" */ '@theme/components/Pagination.vue'),
     },
     created(){
-        this.$page.frontmatter.title = 'hello world'
+        // this.$page.frontmatter.title = 'hello world'
     }
 }
 </script>


### PR DESCRIPTION
1. 通过搜索引擎可以看到站点很多收录页面标题被置为 hello world，定位到一句代码，直接注释掉了，不清楚是否有其他作用，目前看着没问题。
2. XML代码高亮受 .tag 影响无法正常显示，为 .tag 样式添加了 scoped